### PR TITLE
Bugfix :  when game directory ends with '\' subdirectory extraction fails

### DIFF
--- a/DSR-TPUP/TPUP.cs
+++ b/DSR-TPUP/TPUP.cs
@@ -47,8 +47,17 @@ namespace DSR_TPUP
             stop = false;
             conversionWarning = false;
             preserveConverted = setPreserve;
-            gameDir = Path.GetFullPath(setGameDir);
-            looseDir = Path.GetFullPath(setLooseDir);
+
+            if (setGameDir.EndsWith("\\"))
+                gameDir = setGameDir.Substring(0, setGameDir.Length-1);
+            else
+                gameDir = Path.GetFullPath(setGameDir);
+
+            if (setLooseDir.EndsWith("\\"))
+                looseDir = setLooseDir.Substring(0, setLooseDir.Length - 1);
+            else
+                looseDir = Path.GetFullPath(setLooseDir);
+
             repack = setRepack;
             Log = new ConcurrentQueue<string>();
             Error = new ConcurrentQueue<string>();


### PR DESCRIPTION
for example gameDir = "D:\\games\\DS remastered\\" the subdirectory "chr" is extracted as "hr"
this commit removes the last slash (if found) from directories when TPUP class is created